### PR TITLE
Update utterances.json

### DIFF
--- a/utterances.json
+++ b/utterances.json
@@ -1,6 +1,7 @@
 {
   "origins": [
     "http://yceffort.kr",
-    "https://yceffort.kr"
+    "https://yceffort.kr",
+    "https://www.yceffort.kr"
   ]
 }


### PR DESCRIPTION
블로그에 댓글 작성하려니 아래와 같이 에러가 뜨네요..
Error: https://www.yceffort.kr is not permitted to post to yceffort/yceffort-blog-comments. Confirm this is the correct repo for this site's comments. If you own this repo, update the utterances.json to include https://www.yceffort.kr in the list of origins.

Suggested configuration:
{
  "origins": [
    "https://www.yceffort.kr"
  ]
}